### PR TITLE
Add rejection sampling method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXContexts"
 uuid = "04c26001-d4a1-49d2-b090-1d469cf06784"
 authors = ["QuantEx team"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/examples/ghz/ghz_5.yml
+++ b/examples/ghz/ghz_5.yml
@@ -1,10 +1,12 @@
-amplitudes:
-  - "01000"
-  - "01110"
-  - "10101"
-  - "10001"
-  - "10010"
-  - "11111"
+output:
+  output_method: list
+  bitstrings:
+    - "11111"
+    - "11010"
+    - "01110"
+    - "00110"
+    - "10100"
+    - "01001"
 partitions:
   parameters:
     v1: 2

--- a/examples/ghz/ghz_5.yml
+++ b/examples/ghz/ghz_5.yml
@@ -1,12 +1,13 @@
 output:
-  output_method: list
-  bitstrings:
-    - "01000"
-    - "01110"
-    - "10101"
-    - "10001"
-    - "10010"
-    - "11111"
+  method: List
+  params:
+    bitstrings:
+      - "01000"
+      - "01110"
+      - "10101"
+      - "10001"
+      - "10010"
+      - "11111"
 partitions:
   parameters:
     v1: 2

--- a/examples/ghz/ghz_5.yml
+++ b/examples/ghz/ghz_5.yml
@@ -1,12 +1,12 @@
 output:
   output_method: list
   bitstrings:
-    - "11111"
-    - "11010"
+    - "01000"
     - "01110"
-    - "00110"
-    - "10100"
-    - "01001"
+    - "10101"
+    - "10001"
+    - "10010"
+    - "11111"
 partitions:
   parameters:
     v1: 2

--- a/examples/ghz/ghz_5_rejection.yml
+++ b/examples/ghz/ghz_5_rejection.yml
@@ -1,0 +1,11 @@
+output:
+  fix_M: false
+  M: 0.001
+  num_samples: 10
+  output_method: rejection
+  seed: 42
+  num_qubits: 5
+partitions:
+  parameters:
+    v1: 2
+    v2: 2

--- a/examples/ghz/ghz_5_rejection.yml
+++ b/examples/ghz/ghz_5_rejection.yml
@@ -1,10 +1,11 @@
 output:
-  fix_M: false
-  M: 0.001
-  num_samples: 10
-  output_method: rejection
-  seed: 42
-  num_qubits: 5
+  method: Rejection
+  params:
+    num_qubits: 5
+    num_samples: 10
+    M: 0.001
+    fix_M: false
+    seed: 42
 partitions:
   parameters:
     v1: 2

--- a/examples/ghz/ghz_5_uniform.yml
+++ b/examples/ghz/ghz_5_uniform.yml
@@ -1,0 +1,9 @@
+output:
+  num_samples: 10
+  output_method: uniform
+  seed: 42
+  num_qubits: 5
+partitions:
+  parameters:
+    v1: 2
+    v2: 2

--- a/examples/ghz/ghz_5_uniform.yml
+++ b/examples/ghz/ghz_5_uniform.yml
@@ -1,8 +1,9 @@
 output:
-  num_samples: 10
-  output_method: uniform
-  seed: 42
-  num_qubits: 5
+  method: Uniform
+  params:
+    num_samples: 10
+    seed: 42
+    num_qubits: 5
 partitions:
   parameters:
     v1: 2

--- a/src/QXContexts.jl
+++ b/src/QXContexts.jl
@@ -2,12 +2,14 @@ module QXContexts
 
 using Reexport
 
+include("sampling.jl")
 include("logger.jl")
 include("parameters.jl")
 include("dsl.jl")
 include("execution.jl")
 include("sysimage/sysimage.jl")
 
+@reexport using QXContexts.Sampling
 @reexport using QXContexts.Logger
 @reexport using QXContexts.Param
 @reexport using QXContexts.DSL

--- a/src/QXContexts.jl
+++ b/src/QXContexts.jl
@@ -2,17 +2,17 @@ module QXContexts
 
 using Reexport
 
-include("sampling.jl")
 include("logger.jl")
 include("parameters.jl")
 include("dsl.jl")
 include("execution.jl")
 include("sysimage/sysimage.jl")
+include("sampling.jl")
 
-@reexport using QXContexts.Sampling
 @reexport using QXContexts.Logger
 @reexport using QXContexts.Param
 @reexport using QXContexts.DSL
 @reexport using QXContexts.Execution
+@reexport using QXContexts.Sampling
 
 end

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -13,9 +13,12 @@ import LinearAlgebra
 import TensorOperations
 import QXContexts.Logger: @debug
 using TimerOutputs
+using Random
 using OMEinsum
 using QXContexts.DSL
 using QXContexts.Param
+using QXContexts.Sampling
+import QXContexts
 
 const timer_output = TimerOutput()
 if haskey(ENV, "QXRUN_TIMER")

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -338,10 +338,6 @@ function execute(dsl_file::String,
     ctx = QXContext(commands, partition_params, input_file)
     if comm !== nothing
         ctx = QXMPIContext(ctx, comm, sub_comm_size)
-
-        # # Variables needed by a sampler to divide work evenly amongst groups of nodes.
-        # sampler_args[:params][:rank] = MPI.Comm_rank(comm) ÷ sub_comm_size
-        # sampler_args[:params][:comm_size] = MPI.Comm_size(comm) ÷ sub_comm_size
     end
 
     # Create a sampler to produce bitstrings to get amplitudes for and a variable to store 

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -332,7 +332,6 @@ function execute(dsl_file::String,
     # produce bitstrings to compute amplitudes for.
     commands = parse_dsl(dsl_file)
     sampler_args, partition_params = parse_parameters(param_file,
-                                                      max_amplitudes=max_amplitudes, 
                                                       max_parameters=max_parameters)
 
     # Create a context to execute the commands in.
@@ -347,7 +346,7 @@ function execute(dsl_file::String,
 
     # Create a sampler to produce bitstrings to get amplitudes for and a variable to store 
     # the results.
-    sampler = QXContexts.Sampling.create_sampler(sampler_args, ctx)
+    sampler = QXContexts.Sampling.create_sampler(sampler_args, ctx, max_amplitudes)
     results = Samples()
 
     # For each bitstring produced by the sampler, compute its amplitude and accept or reject

--- a/src/mpi_execution.jl
+++ b/src/mpi_execution.jl
@@ -4,6 +4,7 @@ General utility functions for working with MPI and partitions
 
 export get_rank_size
 export get_rank_start
+export get_rank_range
 
 """
     get_rank_size(n::Integer, size::Integer, rank::Integer)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -12,37 +12,39 @@ import Base.Iterators: take
                      max_parameters::Union{Int, Nothing}=nothing,
                      max_amplitudes::Union{Int, Nothing}=nothing)
 
-Parse the parameters yml file to read information about partition parameters and their
-dimensions as well as how the sampling of amplitudes will work.
+Parse the parameters yml file to read information about partition parameters and output 
+sampling method.
 
 Example Parameter file
 ======================
 partitions:
-    parameters:
-        v1: 2
-        v2: 2
-        v3: 4
-amplitudes:
-  - "0000"
-  - "0001"
-  - "1111"
-
+  parameters:
+    v1: 2
+    v2: 2
+output:
+  method: List
+  params:
+    bitstrings:
+      - "01000"
+      - "01110"
+      - "10101"
 """
 function parse_parameters(filename::String;
                           max_parameters::Union{Int, Nothing}=nothing,
                           max_amplitudes::Union{Int, Nothing}=nothing)
     param_dict = YAML.load_file(filename, dicttype=OrderedDict{String, Any})
 
-    # parse the paramters section of the parameter file
+    # parse the partition paramters section of the parameter file
     partition_params = param_dict["partitions"]["parameters"]
     max_parameters = max_parameters === nothing ? length(partition_params) : max_parameters
     partition_params = OrderedDict{Symbol, Int}(Symbol(x[1]) => x[2] for x in take(partition_params, max_parameters))
 
-    max_amplitudes === nothing || (param_dict["output"]["num_samples"] = max_amplitudes)
-    sampler = construct_sampler(param_dict["output"])
+    # parse the output method section of the parameter file
+    method_params = OrderedDict{Symbol, Any}(Symbol(x[1]) => x[2] for x in param_dict["output"])
+    method_params[:params] = OrderedDict{Symbol, Any}(Symbol(x[1]) => x[2] for x in method_params[:params])
+    max_amplitudes === nothing || (method_params[:params][:num_samples] = max_amplitudes)
 
-    # return Parameters(amplitudes, variable_symbols, variable_values)
-    return sampler, partition_params
+    return method_params, partition_params
 end
 
 end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -4,6 +4,7 @@ export parse_parameters
 
 import YAML
 using  DataStructures
+using QXContexts.Sampling
 import Base.Iterators: take
 
 """

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -4,7 +4,6 @@ export parse_parameters
 
 import YAML
 using  DataStructures
-using QXContexts.Sampling
 import Base.Iterators: take
 
 """

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -15,10 +15,6 @@ sampling method.
 
 Example Parameter file
 ======================
-partitions:
-  parameters:
-    v1: 2
-    v2: 2
 output:
   method: List
   params:
@@ -26,6 +22,10 @@ output:
       - "01000"
       - "01110"
       - "10101"
+partitions:
+  parameters:
+    v1: 2
+    v2: 2
 """
 function parse_parameters(filename::String;
                           max_parameters::Union{Int, Nothing}=nothing)

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -8,8 +8,7 @@ import Base.Iterators: take
 
 """
     parse_parameters(filename::String;
-                     max_parameters::Union{Int, Nothing}=nothing,
-                     max_amplitudes::Union{Int, Nothing}=nothing)
+                     max_parameters::Union{Int, Nothing}=nothing)
 
 Parse the parameters yml file to read information about partition parameters and output 
 sampling method.
@@ -29,8 +28,7 @@ output:
       - "10101"
 """
 function parse_parameters(filename::String;
-                          max_parameters::Union{Int, Nothing}=nothing,
-                          max_amplitudes::Union{Int, Nothing}=nothing)
+                          max_parameters::Union{Int, Nothing}=nothing)
     param_dict = YAML.load_file(filename, dicttype=OrderedDict{String, Any})
 
     # parse the partition paramters section of the parameter file
@@ -41,7 +39,6 @@ function parse_parameters(filename::String;
     # parse the output method section of the parameter file
     method_params = OrderedDict{Symbol, Any}(Symbol(x[1]) => x[2] for x in param_dict["output"])
     method_params[:params] = OrderedDict{Symbol, Any}(Symbol(x[1]) => x[2] for x in method_params[:params])
-    max_amplitudes === nothing || (method_params[:params][:num_samples] = max_amplitudes)
 
     return method_params, partition_params
 end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -33,21 +33,16 @@ function parse_parameters(filename::String;
                           max_amplitudes::Union{Int, Nothing}=nothing)
     param_dict = YAML.load_file(filename, dicttype=OrderedDict{String, Any})
 
-    #TODO: Revise the way amplitudes are described
-    amplitudes = unique([amplitude for amplitude in param_dict["amplitudes"]])
-    if max_amplitudes !== nothing && length(amplitudes) > max_amplitudes
-        amplitudes = amplitudes[1:max_amplitudes]
-    end
-
     # parse the paramters section of the parameter file
     partition_params = param_dict["partitions"]["parameters"]
     max_parameters = max_parameters === nothing ? length(partition_params) : max_parameters
     partition_params = OrderedDict{Symbol, Int}(Symbol(x[1]) => x[2] for x in take(partition_params, max_parameters))
-    # variables_symbols = [Symbol("\$$v") for v in take(keys(bond_info), max_parameters)]
-    # variable_values = CartesianIndices(Tuple(take(values(bond_info), max_parameters)))
+
+    max_amplitudes === nothing || (param_dict["output"]["num_samples"] = max_amplitudes)
+    sampler = construct_sampler(param_dict["output"])
 
     # return Parameters(amplitudes, variable_symbols, variable_values)
-    return amplitudes, partition_params
+    return sampler, partition_params
 end
 
 end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -1,0 +1,157 @@
+module Sampling
+
+export ListSampler, RejectionSampler, Samples
+export construct_sampler, accept!
+
+using Random
+using DataStructures
+import Base.iterate
+
+
+abstract type AbstractSampler end
+
+
+"""
+Struct to hold the results of contraction and output sampling.
+"""
+struct Samples{T}
+    bitstrings::DefaultDict{String, Int}
+    amplitudes::Dict{String, T}
+end
+
+Samples() = Samples(DefaultDict{String, Int}(0), Dict{String, ComplexF64}())
+
+
+###############################################################################
+# ListSampler
+###############################################################################
+
+"""
+A Sampler struct to compute the amplitudes of a list of bitstrings.
+"""
+struct ListSampler <: AbstractSampler
+    list::Vector{String}
+    ListSampler(params) = new(params["bitstrings"])
+end
+
+
+iterate(sampler::ListSampler) = (sampler.list, nothing)
+iterate(sampler::ListSampler, ::Nothing) = nothing
+
+
+function accept!(results::Samples, ::ListSampler, bitstring_batch::Vector{String})
+    for bitstring in bitstring_batch
+        results.bitstrings[bitstring] += 1
+    end
+end
+
+###############################################################################
+# RejectionSampler
+###############################################################################
+
+"""
+A Sampler struct to use rejection sampling to produce output.
+"""
+mutable struct RejectionSampler <: AbstractSampler
+    num_qubits::Int64
+    num_samples::Int64
+    accepted::Int64
+    M::Float64
+    fix_M::Bool
+    rng::MersenneTwister
+end
+
+function RejectionSampler(params)
+    num_qubits = params["num_qubits"]
+    num_samples = params["num_samples"]
+    M = params["M"]
+    fix_M = params["fix_M"]
+    rng = MersenneTwister(params["seed"])
+    RejectionSampler(num_qubits, num_samples, 0, M, fix_M, rng)
+end
+
+
+function iterate(sampler::RejectionSampler)
+    num_amps = sampler.num_samples - sampler.accepted
+    if num_amps > 0
+        return [prod(rand(sampler.rng, ["0", "1"], sampler.num_qubits)) for _ in 1:(num_amps)], nothing
+    else
+        return nothing
+    end
+end
+
+iterate(sampler::RejectionSampler, ::Nothing) = iterate(sampler)
+
+
+function accept!(results::Samples, sampler::RejectionSampler, bitstring_batch::Vector{String})
+    for bitstring in bitstring_batch
+        amp = results.amplitudes[bitstring]
+        Np = 2^sampler.num_qubits * abs(amp)^2
+        sampler.fix_M && (sampler.M = max(Np, sampler.M))
+
+        u = rand(sampler.rng)
+        if u < Np / sampler.M
+            sampler.accepted += 1
+            results.bitstrings[bitstring] += 1
+        end
+    end
+end
+
+###############################################################################
+# UniformSampler
+###############################################################################
+
+"""
+A Sampler struct to uniformly sample bitstrings and compute their amplitudes.
+"""
+mutable struct UniformSampler <: AbstractSampler
+    num_qubits::Int64
+    num_samples::Int64
+    batch_size::Int64
+    total_batches::Int64
+    rng::MersenneTwister
+end
+
+function UniformSampler(params)
+    num_qubits = params["num_qubits"]
+    num_samples = params["num_samples"]
+    batch_size = params["batch_size"]
+    total_batches = params["total_batches"]
+    rng = MersenneTwister(params["seed"])
+    UniformSampler(num_qubits, num_samples, batch_size, total_batches, rng)
+end
+
+
+function iterate(sampler::UniformSampler)
+    if sampler.total_batches * sampler.batch_size < sampler.num_samples
+        sampler.total_batches += 1
+        return [prod(rand(sampler.rng, ["0", "1"], sampler.num_qubits)) for _ in 1:(sampler.batch_size)], nothing
+    else
+        return nothing
+    end
+end
+
+iterate(sampler::UniformSampler, ::Nothing) = iterate(sampler)
+
+
+function accept!(results::Samples, ::UniformSampler, bitstring_batch::Vector{String})
+    for bitstring in bitstring_batch
+        results.bitstrings[bitstring] += 1
+    end
+end
+
+###############################################################################
+# Sampler Constructor
+###############################################################################
+
+
+CONSTRUCTORS = Base.ImmutableDict(
+    "rejection" => RejectionSampler,
+    "list" => ListSampler
+)
+
+function construct_sampler(params)
+    CONSTRUCTORS[params["output_method"]](params)
+end
+
+end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -205,8 +205,6 @@ end
 Returns a sampler whose type is specified in `params`.
 """
 create_sampler(params) = get_constructor(params[:method])(;params[:params]...)
-get_constructor(func_name::String) = getfield(Main, Symbol(func_name*"Sampler"))
-
 create_sampler(params, ctx::QXContext{T}) where T = create_sampler(params)
 
 function create_sampler(params, ctx::QXMPIContext)
@@ -214,5 +212,12 @@ function create_sampler(params, ctx::QXMPIContext)
     params[:comm_size] = MPI.Comm_size(ctx.comm) ÷ MPI.Comm_size(ctx.sub_comm)
     create_sampler(params)
 end
+
+function create_sampler(params, ctx, max_amplitudes=nothing)
+    max_amplitudes === nothing || (params[:params][:num_samples] = max_amplitudes)
+    create_sampler(params, ctx)
+end
+
+get_constructor(func_name::String) = getfield(Main, Symbol(func_name*"Sampler"))
 
 end

--- a/test/bin_tests.jl
+++ b/test/bin_tests.jl
@@ -24,9 +24,11 @@ include("../bin/qxrun.jl")
                 "-o", output_fname]
         main(args)
         @test isfile(output_fname)
-        output = load(output_fname, "results")
-        expected = collect(values(ghz_results))
-        @test output ≈ expected
+
+        # output = load(output_fname, "results")
+        # expected = collect(values(ghz_results))
+        # @test output ≈ expected
+
         output = load(output_fname, "amplitudes")
         @test all([output[x] ≈ ghz_results[x] for x in keys(output)])
     end
@@ -38,11 +40,14 @@ include("../bin/qxrun.jl")
                 "--number-amplitudes", "1"]
         main(args)
         @test isfile(output_fname)
-        output = load(output_fname, "results")
-        expected = [ghz_results["01000"]]
-        @test output ≈ expected
+
+        # output = load(output_fname, "results")
+        # expected = [ghz_results["01000"]]
+        # @test output ≈ expected
+
         output = load(output_fname, "amplitudes")
-        @test all([output[x] ≈ ghz_results[x] for x in ["11111"]])
+        @test length(output) == 1
+        @test output["01000"] ≈ ghz_results["01000"]
     end
 
     mktempdir() do path
@@ -53,11 +58,14 @@ include("../bin/qxrun.jl")
                 "--number-slices", "1"]
         main(args)
         @test isfile(output_fname)
-        output = load(output_fname, "results")
-        expected = [ghz_results["01000"], ghz_results["01110"]]
-        @test output ≈ expected
+
+        # output = load(output_fname, "results")
+        # expected = [ghz_results["01000"], ghz_results["01110"]]
+        # @test output ≈ expected
+
         output = load(output_fname, "amplitudes")
-        @test all([output[x] ≈ ghz_results[x] for x in ["11111", "11010"]])
+        @test length(output) == 2
+        @test all([output[x] ≈ ghz_results[x] for x in ["01000", "01110"]])
     end
 
 end

--- a/test/bin_tests.jl
+++ b/test/bin_tests.jl
@@ -27,6 +27,8 @@ include("../bin/qxrun.jl")
         output = load(output_fname, "results")
         expected = collect(values(ghz_results))
         @test output ≈ expected
+        output = load(output_fname, "amplitudes")
+        @test all([output[x] ≈ ghz_results[x] for x in keys(output)])
     end
 
     mktempdir() do path
@@ -39,6 +41,8 @@ include("../bin/qxrun.jl")
         output = load(output_fname, "results")
         expected = [ghz_results["01000"]]
         @test output ≈ expected
+        output = load(output_fname, "amplitudes")
+        @test all([output[x] ≈ ghz_results[x] for x in ["11111"]])
     end
 
     mktempdir() do path
@@ -52,6 +56,8 @@ include("../bin/qxrun.jl")
         output = load(output_fname, "results")
         expected = [ghz_results["01000"], ghz_results["01110"]]
         @test output ≈ expected
+        output = load(output_fname, "amplitudes")
+        @test all([output[x] ≈ ghz_results[x] for x in ["11111", "11010"]])
     end
 
 end

--- a/test/bin_tests.jl
+++ b/test/bin_tests.jl
@@ -25,10 +25,6 @@ include("../bin/qxrun.jl")
         main(args)
         @test isfile(output_fname)
 
-        # output = load(output_fname, "results")
-        # expected = collect(values(ghz_results))
-        # @test output ≈ expected
-
         output = load(output_fname, "amplitudes")
         @test all([output[x] ≈ ghz_results[x] for x in keys(output)])
     end
@@ -40,10 +36,6 @@ include("../bin/qxrun.jl")
                 "--number-amplitudes", "1"]
         main(args)
         @test isfile(output_fname)
-
-        # output = load(output_fname, "results")
-        # expected = [ghz_results["01000"]]
-        # @test output ≈ expected
 
         output = load(output_fname, "amplitudes")
         @test length(output) == 1
@@ -58,10 +50,6 @@ include("../bin/qxrun.jl")
                 "--number-slices", "1"]
         main(args)
         @test isfile(output_fname)
-
-        # output = load(output_fname, "results")
-        # expected = [ghz_results["01000"], ghz_results["01110"]]
-        # @test output ≈ expected
 
         output = load(output_fname, "amplitudes")
         @test length(output) == 2

--- a/test/ghzexample_tests.jl
+++ b/test/ghzexample_tests.jl
@@ -28,8 +28,22 @@ using DataStructures
 
         execute(dsl_file, param_file, input_data_file, output_data_file)
         # ensure all dictionary entries match
-        output = FileIO.load(output_data_file, "results")
-        @test output ≈ expected_vals
+        output = FileIO.load(output_data_file, "amplitudes")
+        output_vals = [output[bitstring] for bitstring in keys(expected)]
+        @test output_vals ≈ expected_vals
+    end
+
+
+    param_file = joinpath(test_path, "examples/ghz/ghz_5_rejection.yml")
+
+    mktempdir() do path
+        output_data_file = joinpath(path, "out.jld2")
+        execute(dsl_file, param_file, input_data_file, output_data_file)
+
+        # ensure all dictionary entries match
+        output = FileIO.load(output_data_file, "bitstrings")
+        @test length(output) == 2
+        @test output["11111"] + output["00000"] == 10
     end
 end
 

--- a/test/ghzexample_tests.jl
+++ b/test/ghzexample_tests.jl
@@ -41,7 +41,7 @@ using DataStructures
         execute(dsl_file, param_file, input_data_file, output_data_file)
 
         # ensure all dictionary entries match
-        output = FileIO.load(output_data_file, "bitstrings")
+        output = FileIO.load(output_data_file, "bitstrings_counts")
         @test length(output) == 2
         @test output["11111"] + output["00000"] == 10
     end

--- a/test/sampling_tests.jl
+++ b/test/sampling_tests.jl
@@ -20,7 +20,7 @@ using DataStructures
         execute(dsl_file, param_file, input_data_file, output_data_file)
 
         # ensure all dictionary entries match
-        output = FileIO.load(output_data_file, "bitstrings")
+        output = FileIO.load(output_data_file, "bitstrings_counts")
         @test sum(values(output)) ≈ 10
     end
 
@@ -32,7 +32,7 @@ using DataStructures
         execute(dsl_file, param_file, input_data_file, output_data_file)
 
         # ensure all dictionary entries match
-        output = FileIO.load(output_data_file, "bitstrings")
+        output = FileIO.load(output_data_file, "bitstrings_counts")
         @test length(output) == 2
         @test output["11111"] + output["00000"] == 10
     end

--- a/test/sampling_tests.jl
+++ b/test/sampling_tests.jl
@@ -1,0 +1,41 @@
+module SamplingTests
+
+using QXContexts
+using JLD2
+using FileIO
+using Test
+using DataStructures
+
+@testset "Sampling tests" begin
+
+    test_path = dirname(@__DIR__)
+    dsl_file = joinpath(test_path, "examples/ghz/ghz_5.qx")
+    input_data_file = joinpath(test_path, "examples/ghz/ghz_5.jld2")
+
+
+    param_file  = joinpath(test_path, "examples/ghz/ghz_5_uniform.yml")
+
+    mktempdir() do path
+        output_data_file = joinpath(path, "out.jld2")
+        execute(dsl_file, param_file, input_data_file, output_data_file)
+
+        # ensure all dictionary entries match
+        output = FileIO.load(output_data_file, "bitstrings")
+        @test sum(values(output)) ≈ 10
+    end
+
+
+    param_file = joinpath(test_path, "examples/ghz/ghz_5_rejection.yml")
+
+    mktempdir() do path
+        output_data_file = joinpath(path, "out.jld2")
+        execute(dsl_file, param_file, input_data_file, output_data_file)
+
+        # ensure all dictionary entries match
+        output = FileIO.load(output_data_file, "bitstrings")
+        @test length(output) == 2
+        @test output["11111"] + output["00000"] == 10
+    end
+end
+
+end


### PR DESCRIPTION
### Summary

Added sampler structs to implement different sampling methods, including rejection sampling, Closes #15
A sampler object for the method specified in the yaml file is created when it is parsed Closes #14 

### Rationale

Allows different sampling methods to be used to produce output from simulations. Including frugal rejection sampling and empirical supremum rejection sampling.

#### Implementation Details

#### Additional notes

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
