### PR TITLE
Enable reshape operations

### DIFF
--- a/src/execution.jl
+++ b/src/execution.jl
@@ -69,7 +69,7 @@ function QXContext(::Type{T},
         push!(slice_vals, -1)
     end
 
-    cmds = filter(x -> typeof(x) in [NconCommand, ViewCommand, SaveCommand], cmds)
+    cmds = filter(x -> typeof(x) in [NconCommand, ViewCommand, SaveCommand, ReshapeCommand], cmds)
 
     QXContext{T}(open_bonds, slice_syms, slice_dims, slice_vals, cmds, data)
 end


### PR DESCRIPTION
### Summary

Reshape operations are currently not used if they appear

### Rationale

Reshape operations are useful for merging indices

#### Implementation Details

Update command filter to include reshape commands

#### Additional notes

<hr>

***Check before merging:***

- [ ] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [ ] Incremented the version string in Project.toml file
