### PR TITLE
Remove reexport minor version number from compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXContexts"
 uuid = "04c26001-d4a1-49d2-b090-1d469cf06784"
 authors = ["QuantEx team"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -28,8 +28,8 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 AbstractTrees = "0.3"
-ArgParse = "1.1"
-CUDA = "3.3"
+ArgParse = "1"
+CUDA = "3"
 DataStructures = "0.18"
 FileIO = "1.9"
 JLD2 = "0.4"
@@ -37,7 +37,7 @@ Lazy = "0.15"
 MPI = "0.18"
 OMEinsum = "0.4"
 PackageCompiler = "1.2"
-Reexport = "1.1"
+Reexport = "1"
 TestSetExtensions = "2.0"
 TimerOutputs = "0.5"
 YAML = "0.4"


### PR DESCRIPTION
### Summary

Minor versions not needed in many compat entries

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
