### PR TITLE
Fix debug mode and add timings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXContexts"
 uuid = "04c26001-d4a1-49d2-b090-1d469cf06784"
 authors = ["QuantEx team"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -34,7 +34,7 @@ DataStructures = "0.18"
 FileIO = "1.9"
 JLD2 = "0.4"
 Lazy = "0.15"
-MPI = "0.18"
+MPI = "0.19"
 OMEinsum = "0.4"
 PackageCompiler = "1.2"
 Reexport = "1"

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ julia --project bin/examine_output.jl examples/ghz/out.jld2
 
 ## Enable timing
 
-To get timing information on the different sections of the code the code has been instrumented with [TimerOutputs.jl](https://github.com/KristofferC/TimerOutputs.jl). To enable this one can set the `QXRUN_TIMER` variable to `1`. For example
+To get timing information on the different sections of the code the code has been instrumented with [TimerOutputs.jl](https://github.com/KristofferC/TimerOutputs.jl). To enable this one can add the `--timings` (or `-t`) switch to the CLI command.
 
 ```
-QXRUN_TIMER=1 julia --project bin/qxrun.jl -d examples/ghz/ghz_5.qx -o examples/ghz/out.jld2
+julia --project bin/qxrun.jl -d examples/ghz/ghz_5.qx -o examples/ghz/out.jld2 -t
 ```
 
 ## Enable debugging

--- a/bin/qxrun.jl
+++ b/bin/qxrun.jl
@@ -1,6 +1,7 @@
 # using MPI
 using QXContexts
 using ArgParse
+using TimerOutputs
 
 """
     parse_commandline(ARGS)
@@ -45,9 +46,9 @@ function parse_commandline(ARGS)
         "--gpu", "-g"
             help = "Use GPU if available"
             action = :store_true
-        "-v"
-            help = "Enable verbose output"
-            action = :count_invocations
+        "--timing", "-t"
+            help = "Enable timing with warmup run"
+            action = :store_true
     end
     return parse_args(ARGS, s)
 end
@@ -69,12 +70,24 @@ function main(ARGS)
     sub_comm_size  = args["sub-comm-size"]
     use_mpi        = args["mpi"]
     use_gpu        = args["gpu"]
-    verbose        = args["v"]
+    timing        = args["timing"]
 
-    results = execute(dsl_file, input_file, param_file, output_file;
-                      use_mpi=use_mpi, sub_comm_size=sub_comm_size,
-                      use_gpu=use_gpu, max_amplitudes=number_amplitudes,
-                      max_slices=number_slices)
+    @timeit "Execute" results = execute(dsl_file, input_file, param_file, output_file;
+                                        use_mpi=use_mpi, sub_comm_size=sub_comm_size,
+                                        use_gpu=use_gpu, max_amplitudes=number_amplitudes,
+                                        max_slices=number_slices)
+
+    if timing
+        @info("Timing including compilation")
+        print_timer()
+        reset_timer!()
+        @timeit "Execute" results = execute(dsl_file, input_file, param_file, output_file;
+                                        use_mpi=use_mpi, sub_comm_size=sub_comm_size,
+                                        use_gpu=use_gpu, max_amplitudes=number_amplitudes,
+                                        max_slices=number_slices)
+        @info("Timing after compilation")
+        print_timer()
+    end
 end
 
 

--- a/bin/qxrun.jl
+++ b/bin/qxrun.jl
@@ -46,8 +46,8 @@ function parse_commandline(ARGS)
         "--gpu", "-g"
             help = "Use GPU if available"
             action = :store_true
-        "--timing", "-t"
-            help = "Enable timing with warmup run"
+        "--timings", "-t"
+            help = "Enable output of timings with warmup run"
             action = :store_true
     end
     return parse_args(ARGS, s)
@@ -70,23 +70,21 @@ function main(ARGS)
     sub_comm_size  = args["sub-comm-size"]
     use_mpi        = args["mpi"]
     use_gpu        = args["gpu"]
-    timing        = args["timing"]
+    timings        = args["timings"]
 
-    @timeit "Execute" results = execute(dsl_file, input_file, param_file, output_file;
-                                        use_mpi=use_mpi, sub_comm_size=sub_comm_size,
-                                        use_gpu=use_gpu, max_amplitudes=number_amplitudes,
-                                        max_slices=number_slices)
+    results = execute(dsl_file, input_file, param_file, output_file;
+                      use_mpi=use_mpi, sub_comm_size=sub_comm_size,
+                      use_gpu=use_gpu, max_amplitudes=number_amplitudes,
+                      max_slices=number_slices,
+                      timings=timings)
 
-    if timing
-        @info("Timing including compilation")
-        print_timer()
+    if timings
         reset_timer!()
-        @timeit "Execute" results = execute(dsl_file, input_file, param_file, output_file;
-                                        use_mpi=use_mpi, sub_comm_size=sub_comm_size,
-                                        use_gpu=use_gpu, max_amplitudes=number_amplitudes,
-                                        max_slices=number_slices)
-        @info("Timing after compilation")
-        print_timer()
+        results = execute(dsl_file, input_file, param_file, output_file;
+                          use_mpi=use_mpi, sub_comm_size=sub_comm_size,
+                          use_gpu=use_gpu, max_amplitudes=number_amplitudes,
+                          max_slices=number_slices,
+                          timings=timings)
     end
 end
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -80,10 +80,10 @@ julia --project bin/examine_output.jl examples/ghz/out.jld2
 
 ## Enable timing
 
-To get timing information on the different sections of the code the code has been instrumented with [TimerOutputs.jl](https://github.com/KristofferC/TimerOutputs.jl). To enable this one can set the `QXRUN_TIMER` variable to `1`. For example
+To get timing information on the different sections of the code the code has been instrumented with [TimerOutputs.jl](https://github.com/KristofferC/TimerOutputs.jl). To enable this one can add the `--timings` (or `-t`) switch to the CLI command.
 
 ```
-QXRUN_TIMER=1 julia --project bin/qxrun.jl -d examples/ghz/ghz_5.qx -o examples/ghz/out.jld2
+julia --project bin/qxrun.jl -d examples/ghz/ghz_5.qx -o examples/ghz/out.jld2 -t
 ```
 
 ## Enable debugging

--- a/src/execution.jl
+++ b/src/execution.jl
@@ -76,6 +76,7 @@ end
             output_file::String="";
             max_amplitudes::Union{Int, Nothing}=nothing,
             max_slices::Union{Int, Nothing}=nothing,
+            timings::Bool=false,
             kwargs...)
 
 Main entry point for running calculations. Loads input data, runs computations and
@@ -87,6 +88,7 @@ function execute(dsl_file::String,
                  output_file::String="";
                  max_amplitudes::Union{Int, Nothing}=nothing,
                  max_slices::Union{Int, Nothing}=nothing,
+                 timings::Bool=false,
                  kwargs...)
 
     if input_file === nothing
@@ -104,6 +106,9 @@ function execute(dsl_file::String,
 
     if output_file != "" && results !== nothing
         @timeit "Write results" write_results(results, output_file)
+        if timings
+            print_timer()
+        end
     end
     results
 end


### PR DESCRIPTION
### Summary

Would be useful to get timing information when running from CLI

#### Implementation Details

Use TimerOutputs.jl package and default timer

#### Additional notes

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
