### PR TITLE
31 update samplers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXContexts"
 uuid = "04c26001-d4a1-49d2-b090-1d469cf06784"
 authors = ["QuantEx team"]
-version = "0.2.4"
+version = "0.3.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/compute_graph/tree.jl
+++ b/src/compute_graph/tree.jl
@@ -54,8 +54,8 @@ end
 """
     params(node::ComputeNode, optype::Type=Any)
 
-Compile all parameters from this and descendents with optional op type qualifier.
-This can be used to return only output or view parameters with
+Compile all parameters from this node and descendents with optional op type 
+qualifier. This can be used to return only output or view parameters with
 
 params(node, OutputCommand)
 

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -1,6 +1,6 @@
 module Sampling
 
-export ListSampler #, RejectionSampler, UniformSampler
+export ListSampler, RejectionSampler, UniformSampler
 export create_sampler
 
 using Random
@@ -21,6 +21,10 @@ using QXContexts.Contexts
 
 """Abstract type for samplers"""
 abstract type AbstractSampler end
+
+"""Functions to generate random bitstrings"""
+random_bitstring(rng, num_qubits) = prod(rand(rng, ["0", "1"], num_qubits))
+random_bitstrings(rng, num_qubits, num_samples) = [random_bitstring(rng, num_qubits) for _ in 1:num_samples]
 
 ###############################################################################
 # ListSampler
@@ -72,7 +76,154 @@ function (s::ListSampler)(;max_amplitudes=nothing, kwargs...)
     if amps !== nothing return (bs, amps) end
 end
 
-create_sampler(ctx, sampler_params) = get_constructor(sampler_params[:method])(ctx; sampler_params[:params]...)
-get_constructor(func_name::String) = getfield(@__MODULE__, Symbol(func_name*"Sampler"))
+create_sampler(ctx, sampler_params) = get_constructor(sampler_params[:method])(ctx ;sampler_params[:params]...)
+get_constructor(func_name::String) = getfield(Main, Symbol(func_name*"Sampler"))
+
+
+###############################################################################
+# RejectionSampler
+###############################################################################
+
+"""
+A Sampler struct to use rejection sampling to produce output.
+"""
+mutable struct RejectionSampler <: AbstractSampler
+    ctx::AbstractContext
+    num_qubits::Integer
+    num_samples::Integer
+    M::Real
+    fix_M::Bool
+    rng::MersenneTwister
+end
+
+"""
+    function RejectionSampler(;num_qubits::Integer,
+                              num_samples::Integer,
+                              M::Real=0.0001,
+                              fix_M::Bool=false,
+                              seed::Integer=42,
+                              kwargs...)
+
+Constructor for a RejectionSampler to produce and accept a number of bitstrings.
+"""
+function RejectionSampler(ctx::AbstractContext;
+                          num_qubits::Integer,
+                          num_samples::Integer,
+                          M::Real=0.0001,
+                          fix_M::Bool=false,
+                          seed::Integer=42,
+                          kwargs...)
+    # Evenly divide the number of bitstrings to be sampled amongst the subgroups of ranks.
+    # num_samples = get_rank_size(num_samples, comm_size, rank)
+    rng = MersenneTwister(seed) # TODO: should somehow add the rank to the seed, maybe with get_rank(ctx)?
+    RejectionSampler(ctx, num_qubits, num_samples, M, fix_M, rng)
+end
+
+"""
+    (s::RejectionSampler)(max_amplitudes=nothing, kwargs...)
+
+Callable for RejectionSampler struct. Computes amplitudes for uniformly distributed bitstrings and corrects the distribution
+using a rejection step.
+"""
+function (s::RejectionSampler)(;max_amplitudes=nothing, kwargs...)
+    num_samples = max_amplitudes === nothing ? s.num_samples : max_amplitudes
+    N = 2^s.num_qubits
+    M = s.M
+
+    samples = Samples()
+    accepted = 0
+    while accepted < num_samples
+        # produce cadidate bitstrings
+        bitstrings = random_bitstrings(s.rng, s.num_qubits, num_samples-accepted)
+
+        # compute amplitudes for the bitstrings
+        amps = [compute_amplitude!(s.ctx, bs; kwargs...) for bs in bitstrings]
+        # bs_amp_pairs = [bs => compute_amplitude!(s.ctx, bs; kwargs...) for bs in bitstrings if !(bs in keys(samples.amplitudes))]
+
+        # Record the computed amplitudes and update M if required
+        for (bs, amp) in zip(bitstrings, amps)
+            samples.amplitudes[bs] = amp
+            Np = N * abs(amp)^2
+            s.fix_M || (M = max(Np, M))
+        end
+        s.fix_M || (M = ctxreduceall(s.ctx, max, M))
+
+        # Conduct a rejection step for each bitstring to correct the distribution of samples.
+        for (bs, amp) in zip(bitstrings, amps)
+            Np = N * abs(amp)^2 # This is computed twice
+            if rand(s.rng) < Np / M
+                accepted += 1
+                samples.bitstrings_counts[bs] += 1
+            end
+        end
+    end
+
+    ctxgather(s.ctx, samples)
+    samples
+end
+
+
+###############################################################################
+# UniformSampler
+###############################################################################
+
+"""
+A Sampler struct to uniformly sample bitstrings and compute their amplitudes.
+"""
+mutable struct UniformSampler <: AbstractSampler
+    ctx::AbstractContext
+    num_qubits::Integer
+    num_samples::Integer
+    rng::MersenneTwister
+end
+
+"""
+    UniformSampler(ctx::AbstractContext;
+                    num_qubits::Integer,
+                    num_samples::Integer,
+                    seed::Integer=42,
+                    kwargs...)
+
+Constructor for a UniformSampler to uniformly sample bitstrings.
+"""
+function UniformSampler(ctx::AbstractContext;
+                        num_qubits::Integer,
+                        num_samples::Integer,
+                        seed::Integer=42,
+                        kwargs...)
+    # Evenly divide the number of bitstrings to be sampled amongst the subgroups of ranks.
+    # num_samples = (num_samples ÷ comm_size) + (rank < num_samples % comm_size)
+    rng = MersenneTwister(seed)
+    UniformSampler(ctx, num_qubits, num_samples, rng)
+end
+
+"""
+    (s::UniformSampler)(max_amplitudes=nothing, kwargs...)
+
+Callable for UniformSampler struct. Computes amplitudes for uniformly distributed bitstrings.
+"""
+function (s::UniformSampler)(;max_amplitudes=nothing, kwargs...)
+    num_samples = max_amplitudes === nothing ? s.num_samples : max_amplitudes
+
+    bs = random_bitstrings(s.rng, s.num_qubits, num_samples)
+    amps = ctxmap(s.ctx, x -> compute_amplitude!(s.ctx, x; kwargs...), bs)
+    amps = ctxgather(s.ctx, amps)
+
+    (bs, amps)
+end
+
+###############################################################################
+# Sampler Struct
+###############################################################################
+
+"""
+Struct to hold the results of a simulation.
+"""
+struct Samples{T}
+    bitstrings_counts::DefaultDict{String, <:Integer}
+    amplitudes::Dict{String, T}
+end
+
+Samples() = Samples(DefaultDict{String, Int}(0), Dict{String, ComplexF32}())
 
 end

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -146,7 +146,7 @@ function (s::RejectionSampler)(;max_amplitudes=nothing, kwargs...)
             Np = N * abs(amp)^2
             s.fix_M || (M = max(Np, M))
         end
-        s.fix_M || (M = ctxreduceall(s.ctx, max, M))
+        s.fix_M || (M = ctxreduce(max, s.ctx, M))
 
         # Conduct a rejection step for each bitstring to correct the distribution of samples.
         for (bs, amp) in zip(bitstrings, amps)
@@ -206,7 +206,7 @@ function (s::UniformSampler)(;max_amplitudes=nothing, kwargs...)
     num_samples = max_amplitudes === nothing ? s.num_samples : max_amplitudes
 
     bs = random_bitstrings(s.rng, s.num_qubits, num_samples)
-    amps = ctxmap(s.ctx, x -> compute_amplitude!(s.ctx, x; kwargs...), bs)
+    amps = ctxmap(x -> compute_amplitude!(s.ctx, x; kwargs...), s.ctx, bs)
     amps = ctxgather(s.ctx, amps)
 
     (bs, amps)
@@ -225,5 +225,8 @@ struct Samples{T}
 end
 
 Samples() = Samples(DefaultDict{String, Int}(0), Dict{String, ComplexF32}())
+
+Base.length(s::Samples) = sum(values(s.bitstrings_counts))
+Base.unique(s::Samples) = keys(s.bitstrings_counts)
 
 end

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -29,11 +29,11 @@ include("utils.jl")
     param_file = joinpath(test_path, "examples/ghz/ghz_5_rejection.yml")
 
     mktempdir() do path
-        output_data_file = joinpath(path, "out.jld2")
-        execute(dsl_file, param_file, input_data_file, output_data_file)
+        output_file = joinpath(path, "out.jld2")
+        execute(dsl_file, input_file, param_file, output_file)
 
         # ensure all dictionary entries match
-        output = FileIO.load(output_data_file, "results")
+        output = FileIO.load(output_file, "results")
         @test length(output) == 10 # Should only have 10 samples
         @test length(unique(output)) == 2 # output should only contain strings "11111" and "00000"
     end
@@ -42,11 +42,11 @@ include("utils.jl")
     param_file = joinpath(test_path, "examples/ghz/ghz_5_uniform.yml")
 
     mktempdir() do path
-        output_data_file = joinpath(path, "out.jld2")
-        execute(dsl_file, param_file, input_data_file, output_data_file)
+        output_file = joinpath(path, "out.jld2")
+        execute(dsl_file, input_file, param_file, output_file)
 
         # ensure all dictionary entries match
-        output = FileIO.load(output_data_file, "results")
+        output = FileIO.load(output_file, "results")
         @test length(output[1]) == 10 # Should only have 10 samples
         @test typeof(output[1][1]) == String
         @test length(output[2]) == 10 # should only have 10 amplitudes

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -25,18 +25,33 @@ include("utils.jl")
         @test output[2] ≈ collect(values(ghz_results))
     end
 
+    # Test rejection sampling
+    param_file = joinpath(test_path, "examples/ghz/ghz_5_rejection.yml")
 
-    # param_file = joinpath(test_path, "examples/ghz/ghz_5_rejection.yml")
+    mktempdir() do path
+        output_data_file = joinpath(path, "out.jld2")
+        execute(dsl_file, param_file, input_data_file, output_data_file)
 
-    # mktempdir() do path
-    #     output_data_file = joinpath(path, "out.jld2")
-    #     execute(dsl_file, param_file, input_data_file, output_data_file)
+        # ensure all dictionary entries match
+        output = FileIO.load(output_data_file, "results")
+        @test length(output) == 10 # Should only have 10 samples
+        @test length(unique(output)) == 2 # output should only contain strings "11111" and "00000"
+    end
 
-    #     # ensure all dictionary entries match
-    #     output = FileIO.load(output_data_file, "bitstrings_counts")
-    #     @test length(output) == 2
-    #     @test output["11111"] + output["00000"] == 10
-    # end
+    # Test uniform sampling
+    param_file = joinpath(test_path, "examples/ghz/ghz_5_uniform.yml")
+
+    mktempdir() do path
+        output_data_file = joinpath(path, "out.jld2")
+        execute(dsl_file, param_file, input_data_file, output_data_file)
+
+        # ensure all dictionary entries match
+        output = FileIO.load(output_data_file, "results")
+        @test length(output[1]) == 10 # Should only have 10 samples
+        @test typeof(output[1][1]) == String
+        @test length(output[2]) == 10 # should only have 10 amplitudes
+        @test typeof(output[2][1]) <: Complex
+    end
 end
 
 end


### PR DESCRIPTION
### Summary

Add uniform and rejection samplers. These compute amplitudes for uniformly sampled bitstrings and generate random output bitstrings using rejection sampling respectively. 

### Rationale

#### Implementation Details

#### Additional notes

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
